### PR TITLE
Resets fork version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@vortx/bootstrap",
 	"description": "A custom fork that implements CSS custom properties across the framework. Based on version 5.0.",
-	"version": "0.0.1",
+	"version": "0.1.0",
 	"config": {
 		"version_short": "0.1"
 	},

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-	"name": "bootstrap",
-	"description": "A custom fork that implements CSS custom properties across the framework.",
-	"version": "5.0.1",
+	"name": "@vortx/bootstrap",
+	"description": "A custom fork that implements CSS custom properties across the framework. Based on version 5.0.",
+	"version": "0.0.1",
 	"config": {
-		"version_short": "5.0"
+		"version_short": "0.1"
 	},
 	"keywords": [
 		"css",


### PR DESCRIPTION
This fork needs its own version and namespace so that we can differentiate our changes from base.

I think our release tags should probably include the base Bootstrap version somehow so that we can easily tell which BS version each release is on.